### PR TITLE
fix bug 'animationController is not disposed'

### DIFF
--- a/lib/flutter_radar_chart.dart
+++ b/lib/flutter_radar_chart.dart
@@ -122,6 +122,12 @@ class _RadarChartState extends State<RadarChart>
           this.fraction),
     );
   }
+
+  @override
+  void  dispose() {
+    animationController.dispose();
+    super.dispose();
+  }
 }
 
 class RadarChartPainter extends CustomPainter {


### PR DESCRIPTION
Fix bug.
When RaderChart is disposed, flutter logs outputs messages. 

> I/flutter (18925): The following assertion was thrown while finalizing the widget tree:
> I/flutter (18925): _RadarChartState#14365(ticker active) was disposed with an active Ticker.
> I/flutter (18925): _RadarChartState created a Ticker via its SingleTickerProviderStateMixin, but at the time dispose()
> I/flutter (18925): was called on the mixin, that Ticker was still active. The Ticker must be disposed before calling
> I/flutter (18925): super.dispose().
> I/flutter (18925): Tickers used by AnimationControllers should be disposed by calling dispose() on the
> I/flutter (18925): AnimationController itself. Otherwise, the ticker will leak.

So I send pullrequest to dispose animationController.
Please pull this.